### PR TITLE
ASN.1 (context) tag fixup for derlib

### DIFF
--- a/crypto/der_writer.c
+++ b/crypto/der_writer.c
@@ -17,6 +17,8 @@ static int int_start_context(WPACKET *pkt, int tag)
 {
     if (tag < 0)
         return 1;
+    if (!ossl_assert(tag <= 30))
+        return 0;
     return WPACKET_start_sub_packet(pkt);
 }
 
@@ -24,6 +26,8 @@ static int int_end_context(WPACKET *pkt, int tag)
 {
     if (tag < 0)
         return 1;
+    if (!ossl_assert(tag <= 30))
+        return 0;
     return WPACKET_close(pkt)
         && WPACKET_put_bytes_u8(pkt, DER_C_CONTEXT | tag);
 }

--- a/doc/internal/man3/DER_w_begin_sequence.pod
+++ b/doc/internal/man3/DER_w_begin_sequence.pod
@@ -19,8 +19,8 @@ i.e. the ASN.1 SEQUENCE, SET and CHOICE specifications.  They all come
 in pairs, as noted by the function names containing the words C<begin>
 and B<end>.
 
-When using these, special care must be taken to ensure that I<cont> is
-the same in the matching C<begin> and C<end> function calls.
+When using these, special care must be taken to ensure that the ASN.1 tag
+value I<cont> is the same in the matching C<begin> and C<end> function calls.
 
 DER_w_begin_sequence() and DER_w_end_sequence() begins and ends a
 SEQUENCE.
@@ -29,8 +29,8 @@ SEQUENCE.
 
 All the functions return 1 on success and 0 on failure.  Failure may
 mean that the buffer held by the I<pkt> is too small, but may also
-mean that the values given to the functions are invalid, like a too
-large I<cont>.
+mean that the values given to the functions are invalid, such as the provided
+I<cont> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/DER_w_begin_sequence.pod
+++ b/doc/internal/man3/DER_w_begin_sequence.pod
@@ -9,8 +9,8 @@ DER_w_begin_sequence, DER_w_end_sequence
 
  #include "internal/der.h"
 
- int DER_w_begin_sequence(WPACKET *pkt, int cont);
- int DER_w_end_sequence(WPACKET *pkt, int cont);
+ int DER_w_begin_sequence(WPACKET *pkt, int tag);
+ int DER_w_end_sequence(WPACKET *pkt, int tag);
 
 =head1 DESCRIPTION
 
@@ -20,7 +20,7 @@ in pairs, as noted by the function names containing the words C<begin>
 and B<end>.
 
 When using these, special care must be taken to ensure that the ASN.1 tag
-value I<cont> is the same in the matching C<begin> and C<end> function calls.
+value I<tag> is the same in the matching C<begin> and C<end> function calls.
 
 DER_w_begin_sequence() and DER_w_end_sequence() begins and ends a
 SEQUENCE.
@@ -30,7 +30,7 @@ SEQUENCE.
 All the functions return 1 on success and 0 on failure.  Failure may
 mean that the buffer held by the I<pkt> is too small, but may also
 mean that the values given to the functions are invalid, such as the provided
-I<cont> value being too large for the implementation.
+I<tag> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/DER_w_bn.pod
+++ b/doc/internal/man3/DER_w_bn.pod
@@ -9,10 +9,10 @@ DER_w_boolean, DER_w_ulong, DER_w_bn, DER_w_null
 
  #include "internal/der.h"
 
- int DER_w_boolean(WPACKET *pkt, int cont, int b);
- int DER_w_ulong(WPACKET *pkt, int cont, unsigned long v);
- int DER_w_bn(WPACKET *pkt, int cont, const BIGNUM *v);
- int DER_w_null(WPACKET *pkt, int cont);
+ int DER_w_boolean(WPACKET *pkt, int tag, int b);
+ int DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
+ int DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
+ int DER_w_null(WPACKET *pkt, int tag);
 
 =head1 DESCRIPTION
 
@@ -38,7 +38,7 @@ DER_w_null() writes the primitive NULL.
 All the functions return 1 on success and 0 on failure.  Failure may
 mean that the buffer held by the I<pkt> is too small, but may also
 mean that the values given to the functions are invalid, such as the provided
-I<cont> value being too large for the implementation.
+I<tag> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/DER_w_bn.pod
+++ b/doc/internal/man3/DER_w_bn.pod
@@ -37,8 +37,8 @@ DER_w_null() writes the primitive NULL.
 
 All the functions return 1 on success and 0 on failure.  Failure may
 mean that the buffer held by the I<pkt> is too small, but may also
-mean that the values given to the functions are invalid, like a too
-large I<cont>.
+mean that the values given to the functions are invalid, such as the provided
+I<cont> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/DER_w_precompiled.pod
+++ b/doc/internal/man3/DER_w_precompiled.pod
@@ -29,8 +29,8 @@ held by I<pkt>.
 
 DER_w_precompiled() returns 1 on success and 0 on failure.  Failure
 may mean that the buffer held by the I<pkt> is too small, but may also
-mean that the values given to the functions are invalid, like a too
-large I<cont>.
+mean that the values given to the functions are invalid, such as the provided
+I<cont> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man3/DER_w_precompiled.pod
+++ b/doc/internal/man3/DER_w_precompiled.pod
@@ -9,7 +9,7 @@ DER_w_precompiled
 
  #include "internal/der.h"
 
- int DER_w_precompiled(WPACKET *pkt, int cont,
+ int DER_w_precompiled(WPACKET *pkt, int tag,
                        const unsigned char *precompiled,
                        size_t precompiled_n);
 
@@ -30,7 +30,7 @@ held by I<pkt>.
 DER_w_precompiled() returns 1 on success and 0 on failure.  Failure
 may mean that the buffer held by the I<pkt> is too small, but may also
 mean that the values given to the functions are invalid, such as the provided
-I<cont> value being too large for the implementation.
+I<tag> value being too large for the implementation.
 
 =head1 SEE ALSO
 

--- a/doc/internal/man7/DERlib.pod
+++ b/doc/internal/man7/DERlib.pod
@@ -14,17 +14,17 @@ more similar functions to encode and decode larger structures.
 All these functions have similar function signatures (C<something>
 will vary depending on what the function will encode):
 
-    int DER_w_something(WPACKET *pkt, int cont, ...);
+    int DER_w_something(WPACKET *pkt, int tag, ...);
 
 =begin comment
 
 When readers are added, add this:
 
-    int DER_r_something(PACKET *pkt, int cont, ...);
+    int DER_r_something(PACKET *pkt, int tag, ...);
 
 =end comment
 
-I<pkt> is the packet context used, and I<cont> should be the
+I<pkt> is the packet context used, and I<tag> should be the
 context-specific tag value of the element being handled, or -1 if there
 is no tag number for that element (you may use the convenience macro
 B<DER_NO_CONTEXT> instead of -1).  Any argument following is the C
@@ -55,7 +55,7 @@ B<BIGNUM>s I<r> and I<s>:
           && DER_w_bn(pkg, -1, r)
           && DER_w_end_sequence(pkt, -1);
 
-As an example of the use of I<cont>, an ASN.1 element like this:
+As an example of the use of I<tag>, an ASN.1 element like this:
 
     v [1] INTEGER OPTIONAL
 
@@ -113,10 +113,10 @@ looks as follows. This is a complete function to write that specific
 value:
 
     int DER_w_AlgorithmIdentifier_RSASSA_PSS_special(WPACKET *pkt,
-                                                     int cont,
+                                                     int tag,
                                                      RSA *rsa)
     {
-        return DER_w_begin_sequence(pkt, cont)
+        return DER_w_begin_sequence(pkt, tag)
             && (DER_w_begin_sequence(pkt, DER_NO_CONTEXT)
                 && DER_w_ulong(pkt, 2, 20)
                 && DER_w_precompiled(pkt, 1,
@@ -129,7 +129,7 @@ value:
             && DER_w_precompiled(pkt, DER_NO_CONTEXT,
                                  der_id_RSASSA_PSS,
                                  sizeof(der_id_RSASSA_PSS))
-            && DER_w_end_sequence(pkt, cont);
+            && DER_w_end_sequence(pkt, tag);
     }
 
 =head1 SEE ALSO

--- a/doc/internal/man7/DERlib.pod
+++ b/doc/internal/man7/DERlib.pod
@@ -24,9 +24,9 @@ When readers are added, add this:
 
 =end comment
 
-I<pkt> is the packet context used, and I<cont> should be the context
-number of the element being handled, or -1 if there is no context
-number for that element (you may use the convenience macro
+I<pkt> is the packet context used, and I<cont> should be the
+context-specific tag value of the element being handled, or -1 if there
+is no tag number for that element (you may use the convenience macro
 B<DER_NO_CONTEXT> instead of -1).  Any argument following is the C
 variable that's being encoded or decoded.
 

--- a/include/internal/der.h
+++ b/include/internal/der.h
@@ -69,16 +69,16 @@
 /* This can be used for all items that don't have a context */
 #define DER_NO_CONTEXT  -1
 
-int DER_w_precompiled(WPACKET *pkt, int cont,
+int DER_w_precompiled(WPACKET *pkt, int tag,
                       const unsigned char *precompiled, size_t precompiled_n);
 
-int DER_w_boolean(WPACKET *pkt, int cont, int b);
-int DER_w_ulong(WPACKET *pkt, int cont, unsigned long v);
-int DER_w_bn(WPACKET *pkt, int cont, const BIGNUM *v);
-int DER_w_null(WPACKET *pkt, int cont);
+int DER_w_boolean(WPACKET *pkt, int tag, int b);
+int DER_w_ulong(WPACKET *pkt, int tag, unsigned long v);
+int DER_w_bn(WPACKET *pkt, int tag, const BIGNUM *v);
+int DER_w_null(WPACKET *pkt, int tag);
 
 /*
  * All constructors for constructed elements have a begin and a end function
  */
-int DER_w_begin_sequence(WPACKET *pkt, int cont);
-int DER_w_end_sequence(WPACKET *pkt, int cont);
+int DER_w_begin_sequence(WPACKET *pkt, int tag);
+int DER_w_end_sequence(WPACKET *pkt, int tag);

--- a/providers/common/der/der_dsa.c.in
+++ b/providers/common/der/der_dsa.c.in
@@ -18,12 +18,12 @@
                                        filter => \&oids_to_c::filter_to_C });
 -}
 
-int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int cont, DSA *dsa)
+int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
         && DER_w_precompiled(pkt, -1, der_oid_id_dsa, sizeof(der_oid_id_dsa))
-        && DER_w_end_sequence(pkt, cont);
+        && DER_w_end_sequence(pkt, tag);
 }
 
 #define MD_CASE(name)                                                   \
@@ -32,7 +32,7 @@ int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int cont, DSA *dsa)
         precompiled_sz = sizeof(der_oid_id_dsa_with_##name);     \
         break;
 
-int DER_w_algorithmIdentifier_DSA_with(WPACKET *pkt, int cont,
+int DER_w_algorithmIdentifier_DSA_with(WPACKET *pkt, int tag,
                                        DSA *dsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
@@ -52,8 +52,8 @@ int DER_w_algorithmIdentifier_DSA_with(WPACKET *pkt, int cont,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, cont)
+    return DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
         && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, cont);
+        && DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_dsa.h.in
+++ b/providers/common/der/der_dsa.h.in
@@ -16,6 +16,6 @@
                                        filter => \&oids_to_c::filter_to_H });
 -}
 
-int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int cont, DSA *dsa);
-int DER_w_algorithmIdentifier_DSA_with(WPACKET *pkt, int cont,
+int DER_w_algorithmIdentifier_DSA(WPACKET *pkt, int tag, DSA *dsa);
+int DER_w_algorithmIdentifier_DSA_with(WPACKET *pkt, int tag,
                                        DSA *dsa, int mdnid);

--- a/providers/common/der/der_rsa.c.in
+++ b/providers/common/der/der_rsa.c.in
@@ -18,13 +18,13 @@
                                        filter => \&oids_to_c::filter_to_C });
 -}
 
-int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int cont, RSA *rsa)
+int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa)
 {
-    return DER_w_begin_sequence(pkt, cont)
+    return DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
         && DER_w_precompiled(pkt, -1, der_oid_rsaEncryption,
                              sizeof(der_oid_rsaEncryption))
-        && DER_w_end_sequence(pkt, cont);
+        && DER_w_end_sequence(pkt, tag);
 }
 
 /* Aliases so we can have a uniform MD_CASE */
@@ -43,7 +43,7 @@ int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int cont, RSA *rsa)
         precompiled_sz = sizeof(der_oid_##name##WithRSAEncryption);     \
         break;
 
-int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int cont,
+int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int tag,
                                        RSA *rsa, int mdnid)
 {
     const unsigned char *precompiled = NULL;
@@ -67,8 +67,8 @@ int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int cont,
         return 0;
     }
 
-    return DER_w_begin_sequence(pkt, cont)
+    return DER_w_begin_sequence(pkt, tag)
         /* No parameters (yet?) */
         && DER_w_precompiled(pkt, -1, precompiled, precompiled_sz)
-        && DER_w_end_sequence(pkt, cont);
+        && DER_w_end_sequence(pkt, tag);
 }

--- a/providers/common/der/der_rsa.h.in
+++ b/providers/common/der/der_rsa.h.in
@@ -16,6 +16,6 @@
                                        filter => \&oids_to_c::filter_to_H });
 -}
 
-int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int cont, RSA *rsa);
-int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int cont,
+int DER_w_algorithmIdentifier_RSA(WPACKET *pkt, int tag, RSA *rsa);
+int DER_w_algorithmIdentifier_RSA_with(WPACKET *pkt, int tag,
                                        RSA *rsa, int mdnid);


### PR DESCRIPTION
Rename `cont` to `tag` and reword some of the documentation.

Assert that the provided tag value will fit in the single octet that we try to encod it into!