### PR TITLE
Adjust progs.pl for rc5

### DIFF
--- a/apps/progs.pl
+++ b/apps/progs.pl
@@ -124,6 +124,7 @@ my %cipher_disabler = (
     des3  => "des",
     desx  => "des",
     cast5 => "cast",
+    rc5 => "rc5"
 );
 foreach my $cmd (
     "aes-128-cbc", "aes-128-ecb",


### PR DESCRIPTION
rc5 is not enabled by default so progs.pl needs some adjustment for this.

Prior to this change "openssl list -cipher-commands" was listing rc5 as a
valid cipher command, which subsequently caused test_enc to fail.
