### PR TITLE
Fix script comments regarding cpp32 flags

### DIFF
--- a/util/add-depends.pl
+++ b/util/add-depends.pl
@@ -169,11 +169,10 @@ my %procedures = (
             #
             #   Note: including file: {whatever header file}
             #
-            # With Embarcadero C++Builder's preprocessor (cpp32.exe) the -Hp
-            # flag gives us the preprocessed output annotated with the following
-            # note whenever a #include file is read:
+            # With Embarcadero C++Builder's preprocessor (cpp32.exe) the -Hp -Sx
+            # flags give us the list of #include files read, like the following:
             #
-            #    Including ->->{whatever header file}
+            #   Including ->->{whatever header file}
             #
             # where each "->" indicates the nesting level of the #include.  The
             # logic here is otherwise the same as the 'VC' case.


### PR DESCRIPTION
We're no longer dealing with the full preprocessor output.